### PR TITLE
Update wayne（MI 6X）

### DIFF
--- a/props/wayne_sdk28.prop
+++ b/props/wayne_sdk28.prop
@@ -1,0 +1,3 @@
+ro.build.fingerprint=xiaomi/wayne/wayne:9/PKQ1.180904.001/9.8.22:user/release-keys
+ro.build.description=wayne-user 9 PKQ1.180904.001 9.8.22 release-keys
+ro.build.version.security_patch=2019-09-05


### PR DESCRIPTION
更新了 MI 6X 的 prop文件，扔进压缩包prop文件夹后可直接安装；
适配版本：MIUI10 9.8.22  开发版